### PR TITLE
Update code for ABI changes

### DIFF
--- a/src/abi/Lootery.ts
+++ b/src/abi/Lootery.ts
@@ -153,6 +153,11 @@ export const LOOTERY_ABI = [
   },
   {
     inputs: [],
+    name: "EmptyDisplayName",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "FailedInnerCall",
     type: "error",
   },
@@ -226,6 +231,11 @@ export const LOOTERY_ABI = [
     type: "error",
   },
   {
+    inputs: [],
+    name: "InvalidFeeShares",
+    type: "error",
+  },
+  {
     inputs: [
       {
         internalType: "uint256",
@@ -250,11 +260,22 @@ export const LOOTERY_ABI = [
     inputs: [
       {
         internalType: "uint256",
-        name: "numPicks",
+        name: "maxBallValue",
         type: "uint256",
       },
     ],
-    name: "InvalidNumPicks",
+    name: "InvalidMaxBallValue",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "pickLength",
+        type: "uint256",
+      },
+    ],
+    name: "InvalidPickLength",
     type: "error",
   },
   {
@@ -318,19 +339,8 @@ export const LOOTERY_ABI = [
     type: "error",
   },
   {
-    inputs: [
-      {
-        internalType: "uint256",
-        name: "pickId",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "winningPickId",
-        type: "uint256",
-      },
-    ],
-    name: "NoWin",
+    inputs: [],
+    name: "NoTicketsSpecified",
     type: "error",
   },
   {
@@ -375,22 +385,6 @@ export const LOOTERY_ABI = [
     inputs: [
       {
         internalType: "uint256",
-        name: "requestId",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "timestamp",
-        type: "uint256",
-      },
-    ],
-    name: "RequestAlreadyInFlight",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256",
         name: "actual",
         type: "uint256",
       },
@@ -428,17 +422,6 @@ export const LOOTERY_ABI = [
   {
     inputs: [
       {
-        internalType: "uint256",
-        name: "value",
-        type: "uint256",
-      },
-    ],
-    name: "TicketsSoldOverflow",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
         internalType: "address",
         name: "to",
         type: "address",
@@ -464,11 +447,6 @@ export const LOOTERY_ABI = [
         name: "actual",
         type: "uint8",
       },
-      {
-        internalType: "enum ILootery.GameState",
-        name: "expected",
-        type: "uint8",
-      },
     ],
     name: "UnexpectedState",
     type: "error",
@@ -476,12 +454,23 @@ export const LOOTERY_ABI = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "beneficiary",
+        type: "address",
+      },
+    ],
+    name: "UnknownBeneficiary",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint8[]",
-        name: "picks",
+        name: "pick",
         type: "uint8[]",
       },
     ],
-    name: "UnsortedPicks",
+    name: "UnsortedPick",
     type: "error",
   },
   {
@@ -494,6 +483,25 @@ export const LOOTERY_ABI = [
     ],
     name: "WaitLonger",
     type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "AccruedCommunityFeesWithdrawn",
+    type: "event",
   },
   {
     anonymous: false,
@@ -550,6 +558,25 @@ export const LOOTERY_ABI = [
     inputs: [
       {
         indexed: true,
+        internalType: "address",
+        name: "beneficiary",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "string",
+        name: "displayName",
+        type: "string",
+      },
+    ],
+    name: "BeneficiaryAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
         internalType: "uint256",
         name: "gameId",
         type: "uint256",
@@ -568,6 +595,32 @@ export const LOOTERY_ABI = [
       },
     ],
     name: "BeneficiaryPaid",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "beneficiary",
+        type: "address",
+      },
+    ],
+    name: "BeneficiaryRemoved",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "newCallbackGasLimit",
+        type: "uint256",
+      },
+    ],
+    name: "CallbackGasLimitSet",
     type: "event",
   },
   {
@@ -618,25 +671,6 @@ export const LOOTERY_ABI = [
     anonymous: false,
     inputs: [
       {
-        indexed: false,
-        internalType: "uint256",
-        name: "gameId",
-        type: "uint256",
-      },
-      {
-        indexed: false,
-        internalType: "uint8[]",
-        name: "winningPicks",
-        type: "uint8[]",
-      },
-    ],
-    name: "GameFinalised",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
         indexed: true,
         internalType: "address",
         name: "to",
@@ -648,26 +682,27 @@ export const LOOTERY_ABI = [
         name: "value",
         type: "uint256",
       },
+    ],
+    name: "ExcessRefunded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
       {
         indexed: false,
         internalType: "uint256",
-        name: "gasUsed",
+        name: "gameId",
         type: "uint256",
       },
       {
         indexed: false,
-        internalType: "uint256",
-        name: "gasPrice",
-        type: "uint256",
-      },
-      {
-        indexed: false,
-        internalType: "bool",
-        name: "success",
-        type: "bool",
+        internalType: "uint8[]",
+        name: "winningPick",
+        type: "uint8[]",
       },
     ],
-    name: "GasRefundAttempted",
+    name: "GameFinalised",
     type: "event",
   },
   {
@@ -743,6 +778,44 @@ export const LOOTERY_ABI = [
     anonymous: false,
     inputs: [
       {
+        indexed: false,
+        internalType: "uint256",
+        name: "pickId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "winningPickId",
+        type: "uint256",
+      },
+    ],
+    name: "NoWin",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "OperationalFundsWithdrawn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
         indexed: true,
         internalType: "address",
         name: "previousOwner",
@@ -756,6 +829,44 @@ export const LOOTERY_ABI = [
       },
     ],
     name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+    ],
+    name: "ProtocolFeePaid",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint208",
+        name: "requestId",
+        type: "uint208",
+      },
+      {
+        indexed: false,
+        internalType: "uint48",
+        name: "timestamp",
+        type: "uint48",
+      },
+    ],
+    name: "RandomnessRequested",
     type: "event",
   },
   {
@@ -801,7 +912,7 @@ export const LOOTERY_ABI = [
       {
         indexed: false,
         internalType: "uint8[]",
-        name: "picks",
+        name: "pick",
         type: "uint8[]",
       },
     ],
@@ -885,7 +996,7 @@ export const LOOTERY_ABI = [
   },
   {
     inputs: [],
-    name: "accruedCommunityFees",
+    name: "PROTOCOL_FEE_BPS",
     outputs: [
       {
         internalType: "uint256",
@@ -898,7 +1009,7 @@ export const LOOTERY_ABI = [
   },
   {
     inputs: [],
-    name: "apocalypseGameId",
+    name: "accruedCommunityFees",
     outputs: [
       {
         internalType: "uint256",
@@ -947,6 +1058,56 @@ export const LOOTERY_ABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "beneficiaries",
+    outputs: [
+      {
+        internalType: "address[]",
+        name: "addresses",
+        type: "address[]",
+      },
+      {
+        internalType: "string[]",
+        name: "names",
+        type: "string[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "beneficiary",
+        type: "address",
+      },
+    ],
+    name: "beneficiaryDisplayNames",
+    outputs: [
+      {
+        internalType: "string",
+        name: "name",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "callbackGasLimit",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "uint256",
@@ -955,7 +1116,13 @@ export const LOOTERY_ABI = [
       },
     ],
     name: "claimWinnings",
-    outputs: [],
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "prizeShare",
+        type: "uint256",
+      },
+    ],
     stateMutability: "nonpayable",
     type: "function",
   },
@@ -1004,11 +1171,11 @@ export const LOOTERY_ABI = [
         type: "uint256",
       },
     ],
-    name: "computePicks",
+    name: "computePick",
     outputs: [
       {
         internalType: "uint8[]",
-        name: "picks",
+        name: "pick",
         type: "uint8[]",
       },
     ],
@@ -1023,7 +1190,7 @@ export const LOOTERY_ABI = [
         type: "uint256",
       },
     ],
-    name: "computeWinningBalls",
+    name: "computeWinningPick",
     outputs: [
       {
         internalType: "uint8[]",
@@ -1056,7 +1223,20 @@ export const LOOTERY_ABI = [
     inputs: [],
     name: "draw",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "factory",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -1121,6 +1301,19 @@ export const LOOTERY_ABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "getRequestPrice",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
       {
         components: [
@@ -1141,7 +1334,7 @@ export const LOOTERY_ABI = [
           },
           {
             internalType: "uint8",
-            name: "numPicks",
+            name: "pickLength",
             type: "uint8",
           },
           {
@@ -1198,6 +1391,19 @@ export const LOOTERY_ABI = [
     name: "init",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "isApocalypseMode",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -1297,13 +1503,24 @@ export const LOOTERY_ABI = [
     type: "function",
   },
   {
-    inputs: [],
-    name: "numPicks",
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "gameId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "pickId",
+        type: "uint256",
+      },
+    ],
+    name: "numWinnersInGame",
     outputs: [
       {
-        internalType: "uint8",
+        internalType: "uint256",
         name: "",
-        type: "uint8",
+        type: "uint256",
       },
     ],
     stateMutability: "view",
@@ -1352,7 +1569,7 @@ export const LOOTERY_ABI = [
           },
           {
             internalType: "uint8[]",
-            name: "picks",
+            name: "pick",
             type: "uint8[]",
           },
         ],
@@ -1364,6 +1581,19 @@ export const LOOTERY_ABI = [
     name: "ownerPick",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pickLength",
+    outputs: [
+      {
+        internalType: "uint8",
+        name: "",
+        type: "uint8",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -1390,7 +1620,7 @@ export const LOOTERY_ABI = [
           },
           {
             internalType: "uint8[]",
-            name: "picks",
+            name: "pick",
             type: "uint8[]",
           },
         ],
@@ -1621,6 +1851,48 @@ export const LOOTERY_ABI = [
     inputs: [
       {
         internalType: "address",
+        name: "beneficiary",
+        type: "address",
+      },
+      {
+        internalType: "string",
+        name: "displayName",
+        type: "string",
+      },
+      {
+        internalType: "bool",
+        name: "isBeneficiary",
+        type: "bool",
+      },
+    ],
+    name: "setBeneficiary",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "didMutate",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "newCallbackGasLimit",
+        type: "uint256",
+      },
+    ],
+    name: "setCallbackGasLimit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
         name: "renderer",
         type: "address",
       },
@@ -1731,6 +2003,19 @@ export const LOOTERY_ABI = [
         internalType: "string",
         name: "",
         type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "totalSupply",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
       },
     ],
     stateMutability: "view",

--- a/src/abi/LooteryETHAdapter.ts
+++ b/src/abi/LooteryETHAdapter.ts
@@ -45,7 +45,7 @@ export const LOOTERY_ETH_ADAPTER_ABI = [
           },
           {
             internalType: "uint8[]",
-            name: "picks",
+            name: "pick",
             type: "uint8[]",
           },
         ],

--- a/src/components/NumberPicker.tsx
+++ b/src/components/NumberPicker.tsx
@@ -27,7 +27,7 @@ export function NumberPicker({
   name: `numbers.${number}`;
   onRemove?: (index: number) => void;
 }) {
-  const { numPicks, maxBallValue } = useGameConfig();
+  const { pickLength, maxBallValue } = useGameConfig();
 
   return (
     <Controller
@@ -38,7 +38,7 @@ export function NumberPicker({
         fieldState: { error },
         formState: { errors },
       }) => {
-        const disabled = value.size === numPicks;
+        const disabled = value.size === pickLength;
         return (
           <Card className={cn(error && "border-destructive")}>
             <CardHeader>
@@ -93,7 +93,9 @@ export function NumberPicker({
                 type="button"
                 size="sm"
                 variant="outline"
-                onClick={() => onChange(getRandomPicks(numPicks, maxBallValue))}
+                onClick={() =>
+                  onChange(getRandomPicks(pickLength, maxBallValue))
+                }
                 className="gap-2"
               >
                 <DicesIcon size="1em" /> Randomize numbers

--- a/src/components/TicketPurchase.tsx
+++ b/src/components/TicketPurchase.tsx
@@ -107,7 +107,7 @@ export function TicketPurchase({ onPurchase }: { onPurchase?: () => void }) {
   const { address, isConnected } = useAccount();
   const { gameId, gameState } = useCurrentGame();
   const { isActive, accruedCommunityFees } = useGameData({ gameId });
-  const { numPicks, maxBallValue, ticketPrice, prizeToken } = useGameConfig();
+  const { pickLength, maxBallValue, ticketPrice, prizeToken } = useGameConfig();
   const { refetch: refetchTickets } = useTickets({ address, gameId });
 
   const {
@@ -132,7 +132,7 @@ export function TicketPurchase({ onPurchase }: { onPurchase?: () => void }) {
       numbers: [new Set()],
       recipient: zeroAddress,
     },
-    resolver: valibotResolver(makeFieldSchema(numPicks)),
+    resolver: valibotResolver(makeFieldSchema(pickLength)),
   });
   const { fields, append, remove } = useFieldArray({
     control,
@@ -170,7 +170,7 @@ export function TicketPurchase({ onPurchase }: { onPurchase?: () => void }) {
 
       const picks = fields.numbers.map((set) => ({
         whomst: address,
-        picks: [...set].sort((a, b) => a - b),
+        pick: [...set].sort((a, b) => a - b),
       }));
 
       if (PRIZE_TOKEN_IS_NATIVE) {
@@ -238,7 +238,7 @@ export function TicketPurchase({ onPurchase }: { onPurchase?: () => void }) {
     setValue(
       "numbers",
       Array.from({ length: amount }, () =>
-        getRandomPicks(numPicks, maxBallValue)
+        getRandomPicks(pickLength, maxBallValue)
       )
     );
   }
@@ -337,8 +337,8 @@ export function TicketPurchase({ onPurchase }: { onPurchase?: () => void }) {
               Pick your numbers
             </h2>
             <p className="text-muted-foreground">
-              Please pick {numPicks.toLocaleString("en-US")}{" "}
-              {numPicks === 1 ? `number` : `numbers`}
+              Please pick {pickLength.toLocaleString("en-US")}{" "}
+              {pickLength === 1 ? `number` : `numbers`}
             </p>
           </header>
           <ScrollArea

--- a/src/components/Tickets.tsx
+++ b/src/components/Tickets.tsx
@@ -105,7 +105,7 @@ export function Tickets({ gameId }: { gameId: bigint }) {
                   <div className="flex gap-6 items-center justify-between">
                     <div className="space-y-4">
                       <CardTitle>Ticket #{ticket.tokenId}</CardTitle>
-                      <NumbersList numbers={ticket.picks} />
+                      <NumbersList numbers={ticket.pick} />
                       {ticket.claimStatus?.hasBeenClaimed ? (
                         <p className="text-muted-foreground">Claimed</p>
                       ) : (

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -31,11 +31,11 @@ export const PRIZE_TOKEN_IS_NATIVE = true;
 
 // The contract address of the lottery
 export const CONTRACT_ADDRESS: Address =
-  "0x5096e81b883e9DeF82c21D5ebC666541a5354fc7";
+  "0x09BFa081ad54C0EfdAC38CE0c6681A9B8618C432";
 
 // The address of the ETH adapter contract
 export const LOOTERY_ETH_ADAPTER_ADDRESS: Address =
-  "0xeF25bdE35653f89229fe37b9F7d82484B8c47e4F";
+  "0xB95C75a28019be64e62863E2C9dc48D0dea8b5cc";
 
 // The URL of the GraphQL API to get ticket data
 export const GRAPHQL_API =

--- a/src/hooks/useCurrentGame.ts
+++ b/src/hooks/useCurrentGame.ts
@@ -6,8 +6,14 @@ import { readContractQueryOptions } from "wagmi/query";
 
 // See Lootery contract
 export enum GameState {
+  /** Unitialised state, i.e. before the `init` function has been called */
+  Uninitialised,
+  /** This is the only state where the jackpot can increase */
   Purchase,
+  /** Waiting for VRF fulfilment */
   DrawPending,
+  /** Lootery is closed (forever) */
+  Dead,
 }
 
 export function useCurrentGame() {

--- a/src/hooks/useGameConfig.ts
+++ b/src/hooks/useGameConfig.ts
@@ -16,7 +16,7 @@ export function useGameConfig() {
       {
         abi: LOOTERY_ABI,
         address: CONTRACT_ADDRESS,
-        functionName: "numPicks",
+        functionName: "pickLength",
       },
       {
         abi: LOOTERY_ABI,
@@ -43,11 +43,11 @@ export function useGameConfig() {
     staleTime: Infinity,
   });
 
-  const [maxBallValue, numPicks, gamePeriod, ticketPrice, prizeToken] = data;
+  const [maxBallValue, pickLength, gamePeriod, ticketPrice, prizeToken] = data;
 
   return {
     maxBallValue,
-    numPicks,
+    pickLength,
     gamePeriod,
     ticketPrice,
     prizeToken,

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -23,7 +23,7 @@ export function useGameData({
       {
         abi: LOOTERY_ABI,
         address: CONTRACT_ADDRESS,
-        functionName: "apocalypseGameId",
+        functionName: "isApocalypseMode",
       },
       {
         abi: LOOTERY_ABI,
@@ -57,7 +57,7 @@ export function useGameData({
 
   const [
     jackpot,
-    apocalypseGameId,
+    isApocalypseMode,
     isActive,
     roundDuration,
     gameData,
@@ -66,8 +66,6 @@ export function useGameData({
 
   const [ticketsSold, startedAt, winningPickId] = gameData;
 
-  const isApocalypse =
-    apocalypseGameId !== 0n && apocalypseGameId - 1n === gameId;
   const roundEndTime = startedAt + roundDuration;
   const roundHasEnded = BigInt(getNowInSeconds()) > roundEndTime;
 
@@ -77,8 +75,7 @@ export function useGameData({
     startedAt,
     winningPickId,
     isActive,
-    isApocalypse,
-    apocalypseGameId,
+    isApocalypse: isApocalypseMode,
     roundDuration,
     roundEndTime,
     roundHasEnded,

--- a/src/hooks/useTicketClaimStatuses.ts
+++ b/src/hooks/useTicketClaimStatuses.ts
@@ -4,7 +4,7 @@ import { useGameData } from "@/hooks/useGameData";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { isAddressEqual, zeroAddress, type Address } from "viem";
 import { useConfig } from "wagmi";
-import { hashFn, readContractsQueryOptions } from "wagmi/query";
+import { readContractsQueryOptions } from "wagmi/query";
 
 export function useTicketClaimStatuses({
   address,
@@ -15,7 +15,7 @@ export function useTicketClaimStatuses({
   ticketIds: bigint[];
   gameId: bigint;
 }) {
-  const { winningPickId, apocalypseGameId, isApocalypse } = useGameData({
+  const { winningPickId, isApocalypse, isActive } = useGameData({
     gameId,
   });
   const config = useConfig();
@@ -52,21 +52,20 @@ export function useTicketClaimStatuses({
   const claimStatuses = ticketIds.reduce(
     (_, tokenId, index) => {
       const owner = ticketOwnerData.at(index)?.result;
-      const ticketGameId = ticketPickIdData.at(index)?.result?.[0];
       const pickId = ticketPickIdData.at(index)?.result?.[1];
 
       const isOwner = !!address && !!owner && isAddressEqual(owner, address);
       const hasBeenClaimed = !!owner && isAddressEqual(owner, zeroAddress);
-      const isApocalypseWinner =
-        isApocalypse && ticketGameId === apocalypseGameId - 1n;
+      const isApocalypseConsolationWinner =
+        isApocalypse && !isActive && winningPickId !== pickId;
       const isJackpotWinner = pickId === winningPickId;
-      const isWinner = isApocalypseWinner || isJackpotWinner;
+      const isWinner = isApocalypseConsolationWinner || isJackpotWinner;
 
       return _.set(tokenId, {
         isOwner,
         hasBeenClaimed,
         isWinner,
-        isApocalypseWinner,
+        isApocalypseWinner: isApocalypseConsolationWinner,
         isJackpotWinner,
       });
     },

--- a/src/hooks/useTickets.ts
+++ b/src/hooks/useTickets.ts
@@ -8,7 +8,7 @@ const ticketsQuery = gql`
     tickets(where: { whomstId: $whomst, gameId: $gameId }) {
       items {
         tokenId
-        picks
+        pick
       }
     }
   }
@@ -18,7 +18,7 @@ interface TicketsData {
   tickets: {
     items: {
       tokenId: string;
-      picks: number[];
+      pick: number[];
     }[];
   };
 }

--- a/src/hooks/useWinningNumbers.ts
+++ b/src/hooks/useWinningNumbers.ts
@@ -4,14 +4,14 @@ import request, { gql } from "graphql-request";
 import type { Address } from "viem";
 
 const winningNumbersQuery = gql`
-  query winningPicks($lotteryId: String!, $gameId: String!) {
+  query winningPick($lotteryId: String!, $gameId: String!) {
     lootery(id: $lotteryId) {
       id
       games(where: { id: $gameId }) {
         items {
           id
           gameId
-          winningPicks
+          winningPick
         }
       }
     }
@@ -22,7 +22,7 @@ interface WinningNumbersData {
   lootery: {
     games: {
       items: {
-        winningPicks: number[];
+        winningPick: number[];
       }[];
     };
   } | null;
@@ -49,7 +49,7 @@ export function useWinningNumbers({
     },
   });
 
-  const numbers = data?.lootery?.games.items.at(0)?.winningPicks;
+  const numbers = data?.lootery?.games.items.at(0)?.winningPick;
 
   return {
     ...rest,


### PR DESCRIPTION
- `numPicks` is now `pickLength`
  - Formal definition: singular "pick" -> a set of numbers representing a single ticket. Plural "picks" -> a list of sets.
- There's no more `apocalypseGameId`, just a boolean `isApocalypseMode`. The mechanism is the same (turn the current running game into the last game).

Other contract changes not implemented in the frontend:
- Display/notice of 5% protocol fee (if turned on).
- It is now possible to pass in `Ticket` structs with empty `pick` array when calling the `purchase` function to simply *donate* to the jackpot+community without receiving a lotto ticket.